### PR TITLE
Adds Hamilton and feature engineering section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is the [Fuzzy Labs](https://fuzzylabs.ai) guide to the universe of free and
 - [Experiment tracking](#experiment-tracking)
 - [Model training](#model-training)
 - [Feature stores](#feature-stores)
+- [Feature engineering](#feature-engineering)
 - [Model deployment and serving](#model-deployment-and-serving)
 - [Model monitoring](#model-monitoring)
 - [Full stacks](#full-stacks)
@@ -74,6 +75,12 @@ Machine learning involves a lot of experimentation. We end up training a lot of 
 | ------------------------------------------------------- | ---------- | ----------------------------------------------- |
 | [Feast](https://feast.dev)                              | Apache 2.0 | A complete open source feature store.           |
 | [Hopsworks](https://github.com/logicalclocks/hopsworks) | AGPL-3.0   | A feature store, feature engineering, and more. |
+
+# Feature Engineering
+
+| Name                                                    | License    | Description                                     |
+| ------------------------------------------------------- | ---------- | ----------------------------------------------- |
+| [Hamilton](https://github.com/stitchfix/hamilton)       | BSD-3 CC   | A way to organize, curate, and scale your feature transform code.   |
 
 # Model deployment and serving
 


### PR DESCRIPTION
[Hamilton](https://github.com/stitchfix/hamilton) was created to help wrangle a feature engineering code base.
It forces decoupling of feature transform logic from materialization, and results
in code that is always unit testable, reusable, and documentation friendly.  

I didn't see an appropriate section to add it, so I created a feature engineering
section - putting it in feature stores wouldn't be the right place.