### PR TITLE
Adds a section for model registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Model registries are used to track the lifecycle of trained machine learning mod
 
 | Name                                       | License    | Description                                                                                       |
 | ------------------------------------------ | ---------- | ------------------------------------------------------------------------------------------------- |
-| [MLFlow](https://mlflow.org)               | Apache 2.0 |            |
+| [MLFlow](https://mlflow.org)               | Apache 2.0 | The ML Flow [model registry](https://mlflow.org/docs/latest/model-registry.html) allows you to store, annotate, discover, and manage models in a central repository.           |
 | [modelstore](https://github.com/operatorai/modelstore)                | Apache 2.0 | A Python library for versioning, storing, and tracking ML model artefacts across several different types of storage. |
 
 # Workflows

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is the [Fuzzy Labs](https://fuzzylabs.ai) guide to the universe of free and
 - [Data version control](#data-version-control)
 - [Experiment tracking](#experiment-tracking)
 - [Model training](#model-training)
+- [Model registries](#model-registries)
 - [Feature stores](#feature-stores)
 - [Model deployment and serving](#model-deployment-and-serving)
 - [Model monitoring](#model-monitoring)
@@ -67,6 +68,16 @@ Machine learning involves a lot of experimentation. We end up training a lot of 
 | [MLFlow](https://mlflow.org)               | Apache 2.0 |                                                                                                   |
 | [Kubeflow](https://www.kubeflow.org)       | Apache 2.0 |                                                                                                   |
 | [Metaflow](https://metaflow.org)           | Apache 2.0 |                                                                                                   |
+
+# Model registries
+
+Model registries are used to track the lifecycle of trained machine learning models.
+
+
+| Name                                       | License    | Description                                                                                       |
+| ------------------------------------------ | ---------- | ------------------------------------------------------------------------------------------------- |
+| [MLFlow](https://mlflow.org)               | Apache 2.0 |            |
+| [modelstore](https://github.com/operatorai/modelstore)                | Apache 2.0 | A Python library for versioning, storing, and tracking ML model artefacts across several different types of storage. |
 
 # Workflows
 


### PR DESCRIPTION
👋  Hello!

This PR adds a new section for model registries and I've added both ML Flow and [modelstore](https://github.com/operatorai/modelstore) to it. _Disclosure:_ I'm the author of the latter.

When reading through the other sections, I saw that this might overlap slightly with experiment tracking, which is described as:

> What exactly do we need to track? typically this includes the code version, data version, input parameters, training performance metrics, as well as the final model assets.

Happy to change this around as you see fit.

Thank you for considering this contribution 🙏 