### PR TITLE
Add feathr (feature store by Linkedin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Model registries are used to track the lifecycle of trained machine learning mod
 | ------------------------------------------------------- | ---------- | ----------------------------------------------- |
 | [Feast](https://feast.dev)                              | Apache 2.0 | A complete open source feature store.           |
 | [Hopsworks](https://github.com/logicalclocks/hopsworks) | AGPL-3.0   | A feature store, feature engineering, and more. |
-
+| [Feathr](https://github.com/feathr-ai/feathr)           | Apache 2.0 | Enterprise-grade, high performance feature store|
 # Feature Engineering
 
 | Name                                                    | License    | Description                                     |


### PR DESCRIPTION
This PR adds [Feathr](https://github.com/feathr-ai/feathr)

**About Feathr:**

Feathr is an open source enterprise-grade, high performance feature store, 
hosted in incubation in the LF AI & Data Foundation.

@archena 
Please let me know if any changes are needed for the description.